### PR TITLE
fix: broken links in contribution.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -153,5 +153,5 @@ or you can just check them on the go, when required
 
 |Description of the resources| links |
 |----------------------------|-------|
-|write proper commit messages| [link]()|
-|code od conduct             |[link]()|
+|write proper commit messages| [link](./COMMIT_MESSAGE_PRACTICES.md)|
+|code od conduct             |[link](./CODE_OF_CONDUCT.md)|


### PR DESCRIPTION
the links in the contribution.md were redirecting to a wrong url , it was fixed now it redirects to it's respective files